### PR TITLE
refactor(init): initialize hass.data early and dynamically discover platforms (no behavior change)

### DIFF
--- a/custom_components/eaton_battery_storage/__init__.py
+++ b/custom_components/eaton_battery_storage/__init__.py
@@ -1,4 +1,5 @@
 import logging
+from importlib.util import find_spec
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
@@ -11,8 +12,30 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup(hass: HomeAssistant, config: dict):
     return True  # Not used for config flow-based setup
 
+
+def _discover_platforms() -> list[str]:
+    """Discover available platforms in this integration package.
+
+    This avoids future edits to this file when adding new platforms.
+    """
+    candidates = ("sensor", "binary_sensor", "number", "button", "switch", "select")
+    available = []
+    for platform in candidates:
+        # Module path relative to this package
+        module_name = f"{__package__}.{platform}"
+        if find_spec(module_name) is not None:
+            available.append(platform)
+    # Always keep sensor first for backward compatibility
+    available.sort(key=lambda p: (p != "sensor", p))
+    return available
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     _LOGGER.debug("Setting up Eaton xStorage Home from config entry.")
+
+    # Ensure our domain storage exists before use
+    hass.data.setdefault(DOMAIN, {})
+
     api = EatonBatteryAPI(
         username=entry.data["username"],
         password=entry.data["password"],
@@ -20,22 +43,31 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         host=entry.data["host"],
         app_id="com.eaton.xstoragehome",
         name="Eaton xStorage Home",
-        manufacturer="Eaton"
+        manufacturer="Eaton",
     )
     await api.connect()
     hass.data[DOMAIN]["api"] = api
+
     coordinator = EatonXstorageHomeCoordinator(hass, api)
     await coordinator.async_config_entry_first_refresh()
-
-    hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN]["coordinator"] = coordinator
 
-    hass.async_create_task(
-        hass.config_entries.async_forward_entry_setups(entry, ["sensor"])
-    )
+    # Dynamically forward setups for any available platforms in this package
+    platforms = _discover_platforms()
+    _LOGGER.debug("Discovered platforms: %s", platforms)
+    if platforms:
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_setups(entry, platforms)
+        )
 
     return True
+
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
-    await hass.config_entries.async_forward_entry_unload(entry, "sensor")
-    return True
+    # Attempt to unload all available platforms dynamically as well
+    platforms = _discover_platforms()
+    results = [
+        await hass.config_entries.async_forward_entry_unload(entry, platform)
+        for platform in platforms
+    ]
+    return all(results) if results else True


### PR DESCRIPTION
Summary:
Initialize hass.data[DOMAIN] before use.
Discover and forward available platforms dynamically (sensor first), unload dynamically.

Why:
Avoid future edits to `__init__.py` when adding new platforms; reduces merge conflicts across PRs.

Risk:
Low; additive refactor.

Testing:
Manual smoke: config entry load/unload; sensor entities present.