### PR TITLE
feat(select): default and current operation mode selects (safe defaults, coordinator fallback)

### DIFF
--- a/custom_components/eaton_battery_storage/__init__.py
+++ b/custom_components/eaton_battery_storage/__init__.py
@@ -1,4 +1,5 @@
 import logging
+from importlib.util import find_spec
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
@@ -11,8 +12,30 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup(hass: HomeAssistant, config: dict):
     return True  # Not used for config flow-based setup
 
+
+def _discover_platforms() -> list[str]:
+    """Discover available platforms in this integration package.
+
+    This avoids future edits to this file when adding new platforms.
+    """
+    candidates = ("sensor", "binary_sensor", "number", "button", "switch", "select")
+    available = []
+    for platform in candidates:
+        # Module path relative to this package
+        module_name = f"{__package__}.{platform}"
+        if find_spec(module_name) is not None:
+            available.append(platform)
+    # Always keep sensor first for backward compatibility
+    available.sort(key=lambda p: (p != "sensor", p))
+    return available
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     _LOGGER.debug("Setting up Eaton xStorage Home from config entry.")
+
+    # Ensure our domain storage exists before use
+    hass.data.setdefault(DOMAIN, {})
+
     api = EatonBatteryAPI(
         username=entry.data["username"],
         password=entry.data["password"],
@@ -20,22 +43,31 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         host=entry.data["host"],
         app_id="com.eaton.xstoragehome",
         name="Eaton xStorage Home",
-        manufacturer="Eaton"
+        manufacturer="Eaton",
     )
     await api.connect()
     hass.data[DOMAIN]["api"] = api
+
     coordinator = EatonXstorageHomeCoordinator(hass, api)
     await coordinator.async_config_entry_first_refresh()
-
-    hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN]["coordinator"] = coordinator
 
-    hass.async_create_task(
-        hass.config_entries.async_forward_entry_setups(entry, ["sensor"])
-    )
+    # Dynamically forward setups for any available platforms in this package
+    platforms = _discover_platforms()
+    _LOGGER.debug("Discovered platforms: %s", platforms)
+    if platforms:
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_setups(entry, platforms)
+        )
 
     return True
+
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
-    await hass.config_entries.async_forward_entry_unload(entry, "sensor")
-    return True
+    # Attempt to unload all available platforms dynamically as well
+    platforms = _discover_platforms()
+    results = [
+        await hass.config_entries.async_forward_entry_unload(entry, platform)
+        for platform in platforms
+    ]
+    return all(results) if results else True

--- a/custom_components/eaton_battery_storage/button.py
+++ b/custom_components/eaton_battery_storage/button.py
@@ -1,0 +1,118 @@
+import logging
+from homeassistant.components.button import ButtonEntity
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.helpers.entity import EntityCategory
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    coordinator = hass.data[DOMAIN]["coordinator"]
+    entities = [
+        EatonXStorageMarkNotificationsReadButton(coordinator),
+        EatonXStorageStopCurrentOperationButton(coordinator),
+    ]
+    async_add_entities(entities)
+
+class EatonXStorageMarkNotificationsReadButton(CoordinatorEntity, ButtonEntity):
+    """Button to mark all notifications as read."""
+
+    def __init__(self, coordinator):
+        super().__init__(coordinator)
+        self.coordinator = coordinator
+
+    @property
+    def name(self):
+        return "Mark All Notifications Read"
+
+    @property
+    def unique_id(self):
+        return "eaton_xstorage_mark_notifications_read"
+
+    @property
+    def icon(self):
+        return "mdi:email-mark-as-unread"
+
+    @property
+    def entity_category(self):
+        return EntityCategory.CONFIG
+
+    @property
+    def device_info(self):
+        return getattr(self.coordinator, "device_info", None) or {
+            "identifiers": {(DOMAIN, self.coordinator.api.host)},
+            "name": "Eaton xStorage Home",
+            "manufacturer": "Eaton",
+            "model": "xStorage Home",
+            "entry_type": "service",
+            "configuration_url": f"https://{self.coordinator.api.host}",
+        }
+
+    async def async_press(self):
+        try:
+            result = await self.coordinator.api.mark_all_notifications_read()
+            if result.get("successful"):
+                _LOGGER.info("Marked all notifications as read")
+                await self.coordinator.async_request_refresh()
+            else:
+                _LOGGER.error(f"Failed to mark notifications as read: {result}")
+        except Exception as e:
+            _LOGGER.error(f"Error marking notifications as read: {e}")
+
+    @property
+    def should_poll(self):
+        return False
+
+
+class EatonXStorageStopCurrentOperationButton(CoordinatorEntity, ButtonEntity):
+    """Button to stop/cancel current operation by setting to basic mode."""
+
+    def __init__(self, coordinator):
+        super().__init__(coordinator)
+        self.coordinator = coordinator
+
+    @property
+    def name(self):
+        return "Stop Current Operation"
+
+    @property
+    def unique_id(self):
+        return "eaton_xstorage_stop_current_operation"
+
+    @property
+    def icon(self):
+        return "mdi:stop-circle"
+
+    @property
+    def entity_category(self):
+        return EntityCategory.CONFIG
+
+    @property
+    def device_info(self):
+        return getattr(self.coordinator, "device_info", None) or {
+            "identifiers": {(DOMAIN, self.coordinator.api.host)},
+            "name": "Eaton xStorage Home",
+            "manufacturer": "Eaton",
+            "model": "xStorage Home",
+            "entry_type": "service",
+            "configuration_url": f"https://{self.coordinator.api.host}",
+        }
+
+    async def async_press(self):
+        try:
+            import asyncio
+            result = await self.coordinator.api.send_device_command("SET_BASIC_MODE", 1, {})
+            if result.get("successful", result.get("result") is not None):
+                _LOGGER.info("Stopped current operation (basic mode)")
+                await asyncio.sleep(1)
+            else:
+                _LOGGER.warning(f"Stop operation may not have succeeded: {result}")
+                await asyncio.sleep(1)
+            await self.coordinator.async_request_refresh()
+        except Exception as e:
+            _LOGGER.error(f"Error stopping current operation: {e}")
+            await self.coordinator.async_request_refresh()
+
+    @property
+    def should_poll(self):
+        return False

--- a/custom_components/eaton_battery_storage/coordinator.py
+++ b/custom_components/eaton_battery_storage/coordinator.py
@@ -1,6 +1,7 @@
 import logging
 from datetime import timedelta
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -14,9 +15,114 @@ class EatonXstorageHomeCoordinator(DataUpdateCoordinator):
         )
         self.api = api
 
+    @property
+    def battery_level(self):
+        try:
+            return self.data.get("status", {}).get("energyFlow", {}).get("stateOfCharge")
+        except Exception:
+            return None
+
+    @property
+    def device_info(self):
+        device_data = self.data.get("device", {}) if self.data else {}
+        info = {
+            "identifiers": {(DOMAIN, self.api.host)},
+            "name": "Eaton xStorage Home",
+            "manufacturer": "Eaton",
+            "model": "xStorage Home",
+            "entry_type": "service",
+            "configuration_url": f"https://{self.api.host}",
+        }
+        if device_data:
+            if "firmwareVersion" in device_data:
+                info["sw_version"] = device_data["firmwareVersion"]
+            if "inverterModelName" in device_data:
+                info["model"] = f"xStorage Home ({device_data['inverterModelName']})"
+            if "inverterSerialNumber" in device_data:
+                info["serial_number"] = device_data["inverterSerialNumber"]
+                info["identifiers"].add((DOMAIN, device_data["inverterSerialNumber"]))
+            if "bmsFirmwareVersion" in device_data:
+                info["hw_version"] = device_data["bmsFirmwareVersion"]
+        return info
+
     async def _async_update_data(self):
         try:
-            response = await self.api.get_status()
-            return response.get("result", {})  # Extract only the 'result' part
+            # Fetch multiple endpoints; tolerate failures for tech-only ones
+            results = {}
+            status = await self.api.get_status()
+            device = None
+            config_state = None
+            settings = None
+            metrics = None
+            metrics_daily = None
+            schedule = None
+            technical_status = None
+            maintenance_diagnostics = None
+
+            try:
+                device = await self.api.get_device()
+            except Exception:
+                pass
+            try:
+                config_state = await self.api.get_config_state()
+            except Exception:
+                pass
+            try:
+                settings = await self.api.get_settings()
+            except Exception:
+                pass
+            try:
+                metrics = await self.api.get_metrics()
+            except Exception:
+                pass
+            try:
+                metrics_daily = await self.api.get_metrics_daily()
+            except Exception:
+                pass
+            try:
+                schedule = await self.api.get_schedule()
+            except Exception:
+                pass
+            try:
+                technical_status = await self.api.get_technical_status()
+            except Exception:
+                pass
+            try:
+                maintenance_diagnostics = await self.api.get_maintenance_diagnostics()
+            except Exception:
+                pass
+
+            # Build combined data; keep legacy compatibility where possible
+            results["status"] = status.get("result", {}) if status else {}
+            results["device"] = device.get("result", {}) if device else {}
+            results["config_state"] = config_state if config_state else {}
+            results["settings"] = settings.get("result", {}) if settings else {}
+            results["metrics"] = metrics if metrics else {}
+            results["metrics_daily"] = metrics_daily if metrics_daily else {}
+            results["schedule"] = schedule if schedule else {}
+            results["technical_status"] = technical_status.get("result", {}) if technical_status else {}
+            results["maintenance_diagnostics"] = maintenance_diagnostics.get("result", {}) if maintenance_diagnostics else {}
+
+            # Notifications
+            try:
+                notifications = await self.api.get_notifications()
+                unread_count = await self.api.get_unread_notifications_count()
+            except Exception:
+                notifications = None
+                unread_count = None
+            results["notifications"] = notifications.get("result", {}) if notifications else {}
+            results["unread_notifications_count"] = unread_count.get("result", {}) if unread_count else {}
+
+            # Legacy compatibility: expose some status keys at root for sensors using top-level access
+            try:
+                if isinstance(results.get("status"), dict):
+                    # Merge selected subtrees for backward-compat sensors that expect root keys
+                    for key in ("energyFlow", "today", "last30daysEnergyFlow"):
+                        if key in results["status"] and key not in results:
+                            results[key] = results["status"][key]
+            except Exception:
+                pass
+
+            return results
         except Exception as err:
             raise UpdateFailed(f"Error fetching data: {err}")

--- a/custom_components/eaton_battery_storage/number.py
+++ b/custom_components/eaton_battery_storage/number.py
@@ -1,0 +1,362 @@
+import logging
+from homeassistant.components.number import NumberEntity
+from homeassistant.core import HomeAssistant
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.helpers.storage import Store
+from homeassistant.helpers.dispatcher import async_dispatcher_send, async_dispatcher_connect
+from homeassistant.helpers.entity import EntityCategory
+from .const import DOMAIN
+from .number_constants import NUMBER_ENTITIES
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback):
+    coordinator = hass.data[DOMAIN]["coordinator"]
+    store = Store(hass, 1, f"{DOMAIN}_number_values.json")
+    stored = await store.async_load() or {}
+    hass.data[DOMAIN]["number_values"] = stored
+    hass.data[DOMAIN]["number_store"] = store
+    entities = [EatonBatteryNumberEntity(hass, coordinator, desc) for desc in NUMBER_ENTITIES]
+    entities.append(EatonXStorageHouseConsumptionThresholdNumber(coordinator))
+    entities.append(EatonXStorageBatteryBackupLevelNumber(coordinator))
+    logging.getLogger(__name__).debug("Adding %d number entities (incl. threshold + backup level)", len(entities))
+    for entity in entities:
+        if hasattr(entity, "_all_entities"):
+            entity._all_entities = entities
+    async_add_entities(entities)
+
+class EatonBatteryNumberEntity(CoordinatorEntity, NumberEntity):
+    @property
+    def mode(self):
+        return "box"
+    def __init__(self, hass, coordinator, description):
+        super().__init__(coordinator)
+        self.hass = hass
+        self.coordinator = coordinator
+        self._key = description["key"]
+        self._attr_unique_id = f"eaton_battery_{description['key']}"
+        self._attr_name = description["name"]
+        self._native_min_value = float(description["min"])
+        self._native_max_value = float(description["max"])
+        self._native_step = float(description["step"])
+        self._native_unit_of_measurement = description["unit"]
+        self._attr_device_class = description["device_class"]
+        self._all_entities = None
+
+    async def async_added_to_hass(self):
+        async_dispatcher_connect(self.hass, f"{DOMAIN}_number_update", self._handle_external_update)
+
+    def _handle_external_update(self):
+        self.schedule_update_ha_state()
+
+    @property
+    def extra_state_attributes(self):
+        if self._key == "charge_power":
+            percent = self.native_value
+            if percent is not None:
+                watts = int(round((percent / 100) * 3600))
+                return {"wattage": watts}
+        elif self._key == "charge_power_watt":
+            watts = self.native_value
+            if watts is not None:
+                percent = int(round((watts / 3600) * 100))
+                return {"percent": percent}
+        elif self._key == "discharge_power":
+            percent = self.native_value
+            if percent is not None:
+                watts = int(round((percent / 100) * 3600))
+                return {"wattage": watts}
+        elif self._key == "discharge_power_watt":
+            watts = self.native_value
+            if watts is not None:
+                percent = int(round((watts / 3600) * 100))
+                return {"percent": percent}
+        return None
+
+    @property
+    def native_min_value(self):
+        return self._native_min_value
+
+    @property
+    def native_max_value(self):
+        return self._native_max_value
+
+    @property
+    def native_step(self):
+        return self._native_step
+
+    @property
+    def native_unit_of_measurement(self):
+        return self._native_unit_of_measurement
+
+    @property
+    def native_value(self):
+        return self.hass.data[DOMAIN]["number_values"].get(self._key)
+
+    async def async_set_native_value(self, value: float) -> None:
+        self.hass.data[DOMAIN]["number_values"][self._key] = value
+        linked_key = None
+        if self._key == "charge_power":
+            watts = int(round((value / 100) * 3600))
+            self.hass.data[DOMAIN]["number_values"]["charge_power_watt"] = watts
+            linked_key = "charge_power_watt"
+        elif self._key == "charge_power_watt":
+            percent = int(round((value / 3600) * 100))
+            self.hass.data[DOMAIN]["number_values"]["charge_power"] = percent
+            linked_key = "charge_power"
+        elif self._key == "discharge_power":
+            watts = int(round((value / 100) * 3600))
+            self.hass.data[DOMAIN]["number_values"]["discharge_power_watt"] = watts
+            linked_key = "discharge_power_watt"
+        elif self._key == "discharge_power_watt":
+            percent = int(round((value / 3600) * 100))
+            self.hass.data[DOMAIN]["number_values"]["discharge_power"] = percent
+            linked_key = "discharge_power"
+        await self.hass.data[DOMAIN]["number_store"].async_save(self.hass.data[DOMAIN]["number_values"])
+        if linked_key and self._all_entities:
+            for entity in self._all_entities:
+                if hasattr(entity, "_key") and entity._key == linked_key:
+                    entity.async_write_ha_state()
+        async_dispatcher_send(self.hass, f"{DOMAIN}_number_update")
+        self.async_write_ha_state()
+
+    @property
+    def device_info(self):
+        return getattr(self.coordinator, "device_info", None) or {
+            "identifiers": {(DOMAIN, self.coordinator.api.host)},
+            "name": "Eaton xStorage Home",
+            "manufacturer": "Eaton",
+            "model": "xStorage Home",
+            "entry_type": "service",
+            "configuration_url": f"https://{self.coordinator.api.host}",
+        }
+
+
+class EatonXStorageHouseConsumptionThresholdNumber(CoordinatorEntity, NumberEntity):
+    def __init__(self, coordinator):
+        super().__init__(coordinator)
+        self.coordinator = coordinator
+        self._attr_entity_category = EntityCategory.CONFIG
+        self._optimistic_value = None
+
+    @property
+    def name(self):
+        return "Set House Consumption Threshold"
+
+    @property
+    def unique_id(self):
+        return "eaton_xstorage_set_house_consumption_threshold"
+
+    @property
+    def icon(self):
+        return "mdi:home-lightning-bolt"
+
+    @property
+    def device_info(self):
+        return getattr(self.coordinator, "device_info", None) or {
+            "identifiers": {(DOMAIN, self.coordinator.api.host)},
+            "name": "Eaton xStorage Home",
+            "manufacturer": "Eaton",
+            "model": "xStorage Home",
+            "entry_type": "service",
+            "configuration_url": f"https://{self.coordinator.api.host}",
+        }
+
+    @property
+    def native_unit_of_measurement(self):
+        return "W"
+
+    @property
+    def native_min_value(self):
+        return 300
+
+    @property
+    def native_max_value(self):
+        return 1000
+
+    @property
+    def native_step(self):
+        return 25
+
+    @property
+    def mode(self):
+        return "box"
+
+    @property
+    def native_value(self):
+        if self._optimistic_value is not None:
+            return self._optimistic_value
+        try:
+            device = self.coordinator.data.get("device", {}) if self.coordinator.data else {}
+            if isinstance(device, dict):
+                es = device.get("energySavingMode", {})
+                if isinstance(es, dict) and "houseConsumptionThreshold" in es:
+                    return es.get("houseConsumptionThreshold")
+            settings_data = self.coordinator.data.get("settings", {}) if self.coordinator.data else {}
+            es2 = settings_data.get("energySavingMode", {}) if isinstance(settings_data, dict) else {}
+            return es2.get("houseConsumptionThreshold", 300)
+        except Exception:
+            return 300
+
+    @property
+    def available(self):
+        return self.coordinator.last_update_success and self.coordinator.data is not None
+
+    async def async_set_native_value(self, value: float) -> None:
+        import asyncio
+        _LOGGER = logging.getLogger(__name__)
+        try:
+            self._optimistic_value = int(value)
+            self.async_write_ha_state()
+            current_settings_response = await self.coordinator.api.get_settings()
+            if not current_settings_response or not current_settings_response.get("result"):
+                _LOGGER.error("Failed to get current settings from API")
+                self._optimistic_value = None
+                return
+            current_settings = current_settings_response.get("result", {})
+            if "country" in current_settings and isinstance(current_settings["country"], dict):
+                current_settings["country"] = current_settings["country"].get("geonameId", "")
+            if "city" in current_settings and isinstance(current_settings["city"], dict):
+                current_settings["city"] = current_settings["city"].get("geonameId", "")
+            if "timezone" in current_settings and isinstance(current_settings["timezone"], dict):
+                current_settings["timezone"] = current_settings["timezone"].get("id", "")
+            if "energySavingMode" not in current_settings:
+                current_settings["energySavingMode"] = {}
+            current_settings["energySavingMode"]["houseConsumptionThreshold"] = int(value)
+            payload = {"settings": current_settings}
+            result = await self.coordinator.api.update_settings(payload)
+            if result.get("successful", result.get("result") is not None):
+                _LOGGER.info(f"Set house consumption threshold to {int(value)}W")
+                await asyncio.sleep(2)
+            else:
+                _LOGGER.warning(f"Set threshold may not have succeeded: {result}")
+                await asyncio.sleep(1)
+            await self.coordinator.async_request_refresh()
+            self._optimistic_value = None
+        except Exception as e:
+            _LOGGER.error(f"Error setting house consumption threshold: {e}")
+            self._optimistic_value = None
+            await self.coordinator.async_request_refresh()
+
+    @property
+    def should_poll(self):
+        return False
+
+    def _handle_coordinator_update(self):
+        if self._optimistic_value is not None:
+            self._optimistic_value = None
+        super()._handle_coordinator_update()
+
+
+class EatonXStorageBatteryBackupLevelNumber(CoordinatorEntity, NumberEntity):
+    def __init__(self, coordinator):
+        super().__init__(coordinator)
+        self.coordinator = coordinator
+        self._attr_entity_category = EntityCategory.CONFIG
+        self._optimistic_value = None
+
+    @property
+    def name(self):
+        return "Set Battery Backup Level"
+
+    @property
+    def unique_id(self):
+        return "eaton_xstorage_set_battery_backup_level"
+
+    @property
+    def icon(self):
+        return "mdi:battery-lock"
+
+    @property
+    def native_unit_of_measurement(self):
+        return "%"
+
+    @property
+    def native_min_value(self):
+        return 0
+
+    @property
+    def native_max_value(self):
+        return 100
+
+    @property
+    def native_step(self):
+        return 1
+
+    @property
+    def mode(self):
+        return "box"
+
+    @property
+    def native_value(self):
+        if self._optimistic_value is not None:
+            return self._optimistic_value
+        try:
+            settings_data = self.coordinator.data.get("settings", {}) if self.coordinator.data else {}
+            if isinstance(settings_data, dict) and "bmsBackupLevel" in settings_data:
+                return settings_data.get("bmsBackupLevel")
+            status = self.coordinator.data.get("status", {}) if self.coordinator.data else {}
+            energy_flow = status.get("energyFlow", {}) if isinstance(status, dict) else {}
+            if "batteryBackupLevel" in energy_flow:
+                return energy_flow.get("batteryBackupLevel")
+            return 0
+        except Exception:
+            return 0
+
+    @property
+    def device_info(self):
+        return getattr(self.coordinator, "device_info", None) or {
+            "identifiers": {(DOMAIN, self.coordinator.api.host)},
+            "name": "Eaton xStorage Home",
+            "manufacturer": "Eaton",
+            "model": "xStorage Home",
+            "entry_type": "service",
+            "configuration_url": f"https://{self.coordinator.api.host}",
+        }
+
+    @property
+    def available(self):
+        return self.coordinator.last_update_success and self.coordinator.data is not None
+
+    async def async_set_native_value(self, value: float) -> None:
+        import asyncio
+        _LOGGER = logging.getLogger(__name__)
+        try:
+            self._optimistic_value = int(value)
+            self.async_write_ha_state()
+            current_settings_response = await self.coordinator.api.get_settings()
+            if not current_settings_response or not current_settings_response.get("result"):
+                _LOGGER.error("Failed to get current settings from API")
+                self._optimistic_value = None
+                return
+            current_settings = current_settings_response.get("result", {})
+            if "country" in current_settings and isinstance(current_settings["country"], dict):
+                current_settings["country"] = current_settings["country"].get("geonameId", "")
+            if "city" in current_settings and isinstance(current_settings["city"], dict):
+                current_settings["city"] = current_settings["city"].get("geonameId", "")
+            if "timezone" in current_settings and isinstance(current_settings["timezone"], dict):
+                current_settings["timezone"] = current_settings["timezone"].get("id", "")
+            current_settings["bmsBackupLevel"] = int(value)
+            payload = {"settings": current_settings}
+            result = await self.coordinator.api.update_settings(payload)
+            if result.get("successful", result.get("result") is not None):
+                _LOGGER.info(f"Set battery backup level to {int(value)}%")
+                await asyncio.sleep(2)
+            else:
+                _LOGGER.warning(f"Set backup level may not have succeeded: {result}")
+                await asyncio.sleep(1)
+            await self.coordinator.async_request_refresh()
+            self._optimistic_value = None
+        except Exception as e:
+            _LOGGER.error(f"Error setting battery backup level: {e}")
+            self._optimistic_value = None
+            await self.coordinator.async_request_refresh()
+
+    @property
+    def should_poll(self):
+        return False
+
+    def _handle_coordinator_update(self):
+        if self._optimistic_value is not None:
+            self._optimistic_value = None
+        super()._handle_coordinator_update()

--- a/custom_components/eaton_battery_storage/number_constants.py
+++ b/custom_components/eaton_battery_storage/number_constants.py
@@ -1,0 +1,23 @@
+# Number platform constants for Eaton Battery Storage
+
+CHARGE_END_SOC = "charge_end_soc"
+CHARGE_POWER = "charge_power"
+CHARGE_POWER_WATT = "charge_power_watt"
+CHARGE_DURATION = "charge_duration"
+DISCHARGE_END_SOC = "discharge_end_soc"
+DISCHARGE_POWER = "discharge_power"
+DISCHARGE_POWER_WATT = "discharge_power_watt"
+DISCHARGE_DURATION = "discharge_duration"
+RUN_DURATION = "run_duration"
+
+NUMBER_ENTITIES = [
+    {"key": CHARGE_END_SOC, "name": "Chg SOC", "min": 0, "max": 100, "step": 1, "unit": "%", "device_class": "battery"},
+    {"key": CHARGE_POWER, "name": "Chg Pwr (%)", "min": 5, "max": 100, "step": 1, "unit": "%", "device_class": "power"},
+    {"key": CHARGE_POWER_WATT, "name": "Chg Pwr (W)", "min": 180, "max": 3600, "step": 1, "unit": "W", "device_class": "power"},
+    {"key": CHARGE_DURATION, "name": "Chg Dur", "min": 1, "max": 12, "step": 1, "unit": "h", "device_class": "duration"},
+    {"key": DISCHARGE_END_SOC, "name": "Dischg SOC", "min": 0, "max": 100, "step": 1, "unit": "%", "device_class": "battery"},
+    {"key": DISCHARGE_POWER, "name": "Dischg Pwr (%)", "min": 5, "max": 100, "step": 1, "unit": "%", "device_class": "power"},
+    {"key": DISCHARGE_POWER_WATT, "name": "Dischg Pwr (W)", "min": 180, "max": 3600, "step": 1, "unit": "W", "device_class": "power"},
+    {"key": DISCHARGE_DURATION, "name": "Dischg Dur", "min": 1, "max": 12, "step": 1, "unit": "h", "device_class": "duration"},
+    {"key": RUN_DURATION, "name": "Run Dur", "min": 1, "max": 12, "step": 1, "unit": "h", "device_class": "duration"},
+]

--- a/custom_components/eaton_battery_storage/select.py
+++ b/custom_components/eaton_battery_storage/select.py
@@ -1,0 +1,274 @@
+import asyncio
+import logging
+from homeassistant.components.select import SelectEntity
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.helpers.entity import EntityCategory
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_MODE_OPTIONS = [
+    ("Basic Mode", "SET_BASIC_MODE"),
+    ("Maximize Auto Consumption", "SET_MAXIMIZE_AUTO_CONSUMPTION"),
+    ("Variable Grid Injection", "SET_VARIABLE_GRID_INJECTION"),
+    ("Frequency Regulation", "SET_FREQUENCY_REGULATION"),
+    ("Peak Shaving", "SET_PEAK_SHAVING"),
+]
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    coordinator = hass.data[DOMAIN]["coordinator"]
+    async_add_entities([
+        EatonXStorageDefaultOperationModeSelect(coordinator),
+        EatonXStorageCurrentOperationModeSelect(coordinator),
+    ])
+
+class EatonXStorageDefaultOperationModeSelect(CoordinatorEntity, SelectEntity):
+    def __init__(self, coordinator):
+        super().__init__(coordinator)
+        self.coordinator = coordinator
+        self._attr_entity_category = EntityCategory.CONFIG
+        self._options = [label for (label, _) in DEFAULT_MODE_OPTIONS]
+        self._option_to_cmd = {label: cmd for (label, cmd) in DEFAULT_MODE_OPTIONS}
+        self._cmd_to_label = {cmd: label for (label, cmd) in DEFAULT_MODE_OPTIONS}
+        self._optimistic_option = None
+
+    @property
+    def name(self):
+        return "Default Operation Mode"
+
+    @property
+    def unique_id(self):
+        return "eaton_xstorage_default_operation_mode"
+
+    @property
+    def icon(self):
+        return "mdi:transmission-tower"
+
+    @property
+    def device_info(self):
+        return getattr(self.coordinator, "device_info", None) or {
+            "identifiers": {(DOMAIN, self.coordinator.api.host)},
+            "name": "Eaton xStorage Home",
+            "manufacturer": "Eaton",
+            "model": "xStorage Home",
+            "entry_type": "service",
+            "configuration_url": f"https://{self.coordinator.api.host}",
+        }
+
+    @property
+    def entity_category(self):
+        return EntityCategory.CONFIG
+
+    @property
+    def options(self):
+        return self._options
+
+    @property
+    def current_option(self):
+        if self._optimistic_option is not None:
+            return self._optimistic_option
+        try:
+            settings = self.coordinator.data.get("settings", {}) if self.coordinator.data else {}
+            default_mode = settings.get("defaultMode", {}) if isinstance(settings, dict) else {}
+            cmd = default_mode.get("command")
+            if cmd and cmd in self._cmd_to_label:
+                return self._cmd_to_label[cmd]
+        except Exception:
+            pass
+        return None
+
+    @property
+    def available(self):
+        return self.coordinator.last_update_success and self.coordinator.data is not None
+
+    async def async_select_option(self, option: str) -> None:
+        if option not in self._option_to_cmd:
+            _LOGGER.error("Invalid operation mode option: %s", option)
+            return
+        self._optimistic_option = option
+        self.async_write_ha_state()
+        try:
+            current_settings_response = await self.coordinator.api.get_settings()
+            if not current_settings_response or not current_settings_response.get("result"):
+                _LOGGER.error("Failed to get current settings from API")
+                self._optimistic_option = None
+                return
+            current_settings = current_settings_response.get("result", {})
+            if "country" in current_settings and isinstance(current_settings["country"], dict):
+                current_settings["country"] = current_settings["country"].get("geonameId", "")
+            if "city" in current_settings and isinstance(current_settings["city"], dict):
+                current_settings["city"] = current_settings["city"].get("geonameId", "")
+            if "timezone" in current_settings and isinstance(current_settings["timezone"], dict):
+                current_settings["timezone"] = current_settings["timezone"].get("id", "")
+            command = self._option_to_cmd[option]
+            parameters = {}
+            try:
+                if command == "SET_PEAK_SHAVING":
+                    esm = current_settings.get("energySavingMode", {}) if isinstance(current_settings, dict) else {}
+                    max_peak = None
+                    if isinstance(esm, dict):
+                        max_peak = esm.get("houseConsumptionThreshold")
+                    if isinstance(max_peak, (int, float)):
+                        parameters = {"maxHousePeakConsumption": int(max_peak)}
+                elif command == "SET_VARIABLE_GRID_INJECTION":
+                    parameters = {"maximumPower": 0}
+                elif command == "SET_FREQUENCY_REGULATION":
+                    optimal_soc = current_settings.get("bmsBackupLevel")
+                    if not isinstance(optimal_soc, (int, float)):
+                        status = self.coordinator.data.get("status", {}) if self.coordinator.data else {}
+                        energy_flow = status.get("energyFlow", {}) if isinstance(status, dict) else {}
+                        optimal_soc = energy_flow.get("batteryBackupLevel", 28)
+                    parameters = {"powerAllocation": 0, "optimalSoc": int(optimal_soc)}
+                else:
+                    parameters = {}
+            except Exception:
+                parameters = {}
+            current_settings["defaultMode"] = {"command": command, "parameters": parameters}
+            payload = {"settings": current_settings}
+            result = await self.coordinator.api.update_settings(payload)
+            if result.get("successful", result.get("result") is not None):
+                _LOGGER.info("Default operation mode set to %s", option)
+                await asyncio.sleep(1)
+            else:
+                _LOGGER.warning("Default mode API call may not have succeeded: %s", result)
+                await asyncio.sleep(1)
+            await self.coordinator.async_request_refresh()
+            self._optimistic_option = None
+        except Exception as e:
+            _LOGGER.error("Error setting default operation mode: %s", e)
+            self._optimistic_option = None
+            await self.coordinator.async_request_refresh()
+
+    @property
+    def should_poll(self):
+        return False
+
+    def _handle_coordinator_update(self):
+        if self._optimistic_option is not None:
+            self._optimistic_option = None
+        super()._handle_coordinator_update()
+
+
+class EatonXStorageCurrentOperationModeSelect(CoordinatorEntity, SelectEntity):
+    def __init__(self, coordinator):
+        super().__init__(coordinator)
+        self.coordinator = coordinator
+        self._attr_entity_category = EntityCategory.CONFIG
+        self._options = [label for (label, _) in DEFAULT_MODE_OPTIONS] + ["Manual Charge", "Manual Discharge"]
+        self._option_to_cmd = {label: cmd for (label, cmd) in DEFAULT_MODE_OPTIONS}
+        self._option_to_cmd.update({"Manual Charge": "SET_CHARGE", "Manual Discharge": "SET_DISCHARGE"})
+        self._cmd_to_label = {cmd: label for (label, cmd) in DEFAULT_MODE_OPTIONS}
+        self._cmd_to_label.update({"SET_CHARGE": "Manual Charge", "SET_DISCHARGE": "Manual Discharge"})
+        self._optimistic_option = None
+
+    @property
+    def name(self):
+        return "Current Operation Mode"
+
+    @property
+    def unique_id(self):
+        return "eaton_xstorage_current_operation_mode"
+
+    @property
+    def icon(self):
+        return "mdi:battery-clock"
+
+    @property
+    def device_info(self):
+        return getattr(self.coordinator, "device_info", None) or {
+            "identifiers": {(DOMAIN, self.coordinator.api.host)},
+            "name": "Eaton xStorage Home",
+            "manufacturer": "Eaton",
+            "model": "xStorage Home",
+            "entry_type": "service",
+            "configuration_url": f"https://{self.coordinator.api.host}",
+        }
+
+    @property
+    def entity_category(self):
+        return EntityCategory.CONFIG
+
+    @property
+    def options(self):
+        return self._options
+
+    @property
+    def current_option(self):
+        if self._optimistic_option is not None:
+            return self._optimistic_option
+        try:
+            status = self.coordinator.data.get("status", {}) if self.coordinator.data else {}
+            current_mode = status.get("currentMode", {}) if isinstance(status, dict) else {}
+            cmd = current_mode.get("command")
+            if cmd and cmd in self._cmd_to_label:
+                return self._cmd_to_label[cmd]
+        except Exception:
+            pass
+        return None
+
+    @property
+    def available(self):
+        return self.coordinator.last_update_success and self.coordinator.data is not None
+
+    async def async_select_option(self, option: str) -> None:
+        if option not in self._option_to_cmd:
+            _LOGGER.error("Invalid current operation mode option: %s", option)
+            return
+        self._optimistic_option = option
+        self.async_write_ha_state()
+        try:
+            command = self._option_to_cmd[option]
+            helper_values = self.hass.data[DOMAIN].get("number_values", {})
+            duration = 1
+            if command in ["SET_CHARGE"]:
+                duration = helper_values.get("charge_duration", 1)
+            elif command in ["SET_DISCHARGE"]:
+                duration = helper_values.get("discharge_duration", 1)
+            else:
+                duration = helper_values.get("run_duration", 2)
+            parameters = {}
+            if command == "SET_CHARGE":
+                parameters = {
+                    "action": "ACTION_CHARGE",
+                    "power": int(helper_values.get("charge_power", 15)),
+                    "soc": int(helper_values.get("charge_end_soc", 90)),
+                }
+            elif command == "SET_DISCHARGE":
+                parameters = {
+                    "action": "ACTION_DISCHARGE",
+                    "power": int(helper_values.get("discharge_power", 15)),
+                    "soc": int(helper_values.get("discharge_end_soc", 10)),
+                }
+            elif command == "SET_PEAK_SHAVING":
+                settings = self.coordinator.data.get("settings", {}) if self.coordinator.data else {}
+                esm = settings.get("energySavingMode", {}) if isinstance(settings, dict) else {}
+                max_peak = esm.get("houseConsumptionThreshold", 1000) if isinstance(esm, dict) else 1000
+                parameters = {"maxHousePeakConsumption": int(max_peak)}
+            elif command == "SET_VARIABLE_GRID_INJECTION":
+                parameters = {"maximumPower": 0}
+            elif command == "SET_FREQUENCY_REGULATION":
+                settings = self.coordinator.data.get("settings", {}) if self.coordinator.data else {}
+                optimal_soc = settings.get("bmsBackupLevel", 28) if isinstance(settings, dict) else 28
+                parameters = {"powerAllocation": 0, "optimalSoc": int(optimal_soc)}
+            result = await self.coordinator.api.send_device_command(command, int(duration), parameters)
+            if result.get("successful", result.get("result") is not None):
+                _LOGGER.info("Current operation mode set to %s for %d hours", option, duration)
+                await asyncio.sleep(1)
+            else:
+                _LOGGER.warning("Current mode API call may not have succeeded: %s", result)
+                await asyncio.sleep(1)
+            await self.coordinator.async_request_refresh()
+            self._optimistic_option = None
+        except Exception as e:
+            _LOGGER.error("Error setting current operation mode: %s", e)
+            self._optimistic_option = None
+            await self.coordinator.async_request_refresh()
+
+    @property
+    def should_poll(self):
+        return False
+
+    def _handle_coordinator_update(self):
+        if self._optimistic_option is not None:
+            self._optimistic_option = None
+        super()._handle_coordinator_update()

--- a/custom_components/eaton_battery_storage/switch.py
+++ b/custom_components/eaton_battery_storage/switch.py
@@ -1,0 +1,229 @@
+import logging
+import asyncio
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.helpers.entity import EntityCategory
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    coordinator = hass.data[DOMAIN]["coordinator"]
+    entities = [
+        EatonXStoragePowerSwitch(coordinator),
+        EatonXStorageEnergySavingModeSwitch(coordinator),
+    ]
+    async_add_entities(entities)
+
+class EatonXStoragePowerSwitch(CoordinatorEntity, SwitchEntity):
+    def __init__(self, coordinator):
+        super().__init__(coordinator)
+        self.coordinator = coordinator
+        self._attr_entity_category = EntityCategory.CONFIG
+        self._optimistic_state = None
+
+    @property
+    def name(self):
+        return "Inverter Power"
+
+    @property
+    def unique_id(self):
+        return "eaton_xstorage_inverter_power"
+
+    @property
+    def icon(self):
+        return "mdi:power"
+
+    @property
+    def device_info(self):
+        return getattr(self.coordinator, "device_info", None) or {
+            "identifiers": {(DOMAIN, self.coordinator.api.host)},
+            "name": "Eaton xStorage Home",
+            "manufacturer": "Eaton",
+            "model": "xStorage Home",
+            "entry_type": "service",
+            "configuration_url": f"https://{self.coordinator.api.host}",
+        }
+
+    @property
+    def is_on(self):
+        if self._optimistic_state is not None:
+            return self._optimistic_state
+        try:
+            device_data = self.coordinator.data.get("device", {}) if self.coordinator.data else {}
+            return device_data.get("powerState", False)
+        except Exception:
+            return False
+
+    @property
+    def available(self):
+        return self.coordinator.last_update_success and self.coordinator.data is not None
+
+    async def async_turn_on(self, **kwargs):
+        try:
+            self._optimistic_state = True
+            self.async_write_ha_state()
+            result = await self.coordinator.api.set_device_power(True)
+            if result.get("successful"):
+                _LOGGER.info("Turned on device")
+                await asyncio.sleep(3)
+            else:
+                _LOGGER.warning(f"Power on may not have succeeded: {result}")
+                await asyncio.sleep(2)
+            await self.coordinator.async_request_refresh()
+            self._optimistic_state = None
+        except Exception as e:
+            _LOGGER.error(f"Error turning on device: {e}")
+            self._optimistic_state = None
+            await self.coordinator.async_request_refresh()
+
+    async def async_turn_off(self, **kwargs):
+        try:
+            self._optimistic_state = False
+            self.async_write_ha_state()
+            result = await self.coordinator.api.set_device_power(False)
+            if result.get("successful"):
+                _LOGGER.info("Turned off device")
+                await asyncio.sleep(3)
+            else:
+                _LOGGER.warning(f"Power off may not have succeeded: {result}")
+                await asyncio.sleep(2)
+            await self.coordinator.async_request_refresh()
+            self._optimistic_state = None
+        except Exception as e:
+            _LOGGER.error(f"Error turning off device: {e}")
+            self._optimistic_state = None
+            await self.coordinator.async_request_refresh()
+
+    @property
+    def should_poll(self):
+        return False
+
+    def _handle_coordinator_update(self):
+        if self._optimistic_state is not None:
+            self._optimistic_state = None
+        super()._handle_coordinator_update()
+
+
+class EatonXStorageEnergySavingModeSwitch(CoordinatorEntity, SwitchEntity):
+    def __init__(self, coordinator):
+        super().__init__(coordinator)
+        self.coordinator = coordinator
+        self._attr_entity_category = EntityCategory.CONFIG
+        self._optimistic_state = None
+
+    @property
+    def name(self):
+        return "Energy Saving Mode"
+
+    @property
+    def unique_id(self):
+        return "eaton_xstorage_energy_saving_mode"
+
+    @property
+    def icon(self):
+        return "mdi:leaf"
+
+    @property
+    def device_info(self):
+        return getattr(self.coordinator, "device_info", None) or {
+            "identifiers": {(DOMAIN, self.coordinator.api.host)},
+            "name": "Eaton xStorage Home",
+            "manufacturer": "Eaton",
+            "model": "xStorage Home",
+            "entry_type": "service",
+            "configuration_url": f"https://{self.coordinator.api.host}",
+        }
+
+    @property
+    def is_on(self):
+        if self._optimistic_state is not None:
+            return self._optimistic_state
+        try:
+            settings_data = self.coordinator.data.get("settings", {}) if self.coordinator.data else {}
+            energy_saving_mode = settings_data.get("energySavingMode", {})
+            enabled_value = energy_saving_mode.get("enabled", False)
+            return bool(enabled_value)
+        except Exception:
+            return False
+
+    @property
+    def available(self):
+        return self.coordinator.last_update_success and self.coordinator.data is not None
+
+    async def async_turn_on(self, **kwargs):
+        try:
+            self._optimistic_state = True
+            self.async_write_ha_state()
+            current_settings_response = await self.coordinator.api.get_settings()
+            if not current_settings_response or not current_settings_response.get("result"):
+                _LOGGER.error("Failed to get settings from API")
+                self._optimistic_state = None
+                return
+            current_settings = current_settings_response.get("result", {})
+            if "country" in current_settings and isinstance(current_settings["country"], dict):
+                current_settings["country"] = current_settings["country"].get("geonameId", "")
+            if "city" in current_settings and isinstance(current_settings["city"], dict):
+                current_settings["city"] = current_settings["city"].get("geonameId", "")
+            if "timezone" in current_settings and isinstance(current_settings["timezone"], dict):
+                current_settings["timezone"] = current_settings["timezone"].get("id", "")
+            if "energySavingMode" not in current_settings:
+                current_settings["energySavingMode"] = {}
+            current_settings["energySavingMode"]["enabled"] = True
+            payload = {"settings": current_settings}
+            result = await self.coordinator.api.update_settings(payload)
+            if result.get("successful", result.get("result") is not None):
+                _LOGGER.info("Enabled energy saving mode")
+                await asyncio.sleep(2)
+            else:
+                _LOGGER.warning(f"Enable ESM may not have succeeded: {result}")
+                await asyncio.sleep(1)
+            await self.coordinator.async_request_refresh()
+            self._optimistic_state = None
+        except Exception as e:
+            _LOGGER.error(f"Error enabling energy saving mode: {e}")
+            self._optimistic_state = None
+            await self.coordinator.async_request_refresh()
+
+    async def async_turn_off(self, **kwargs):
+        try:
+            self._optimistic_state = False
+            self.async_write_ha_state()
+            current_settings_response = await self.coordinator.api.get_settings()
+            if not current_settings_response or not current_settings_response.get("result"):
+                _LOGGER.error("Failed to get settings from API")
+                self._optimistic_state = None
+                return
+            current_settings = current_settings_response.get("result", {})
+            if "country" in current_settings and isinstance(current_settings["country"], dict):
+                current_settings["country"] = current_settings["country"].get("geonameId", "")
+            if "city" in current_settings and isinstance(current_settings["city"], dict):
+                current_settings["city"] = current_settings["city"].get("geonameId", "")
+            if "timezone" in current_settings and isinstance(current_settings["timezone"], dict):
+                current_settings["timezone"] = current_settings["timezone"].get("id", "")
+            if "energySavingMode" not in current_settings:
+                current_settings["energySavingMode"] = {}
+            current_settings["energySavingMode"]["enabled"] = False
+            payload = {"settings": current_settings}
+            result = await self.coordinator.api.update_settings(payload)
+            if result.get("successful", result.get("result") is not None):
+                _LOGGER.info("Disabled energy saving mode")
+                await asyncio.sleep(2)
+            else:
+                _LOGGER.warning(f"Disable ESM may not have succeeded: {result}")
+                await asyncio.sleep(1)
+            await self.coordinator.async_request_refresh()
+            self._optimistic_state = None
+        except Exception as e:
+            _LOGGER.error(f"Error disabling energy saving mode: {e}")
+            self._optimistic_state = None
+            await self.coordinator.async_request_refresh()
+
+    @property
+    def should_poll(self):
+        return False
+
+    def _handle_coordinator_update(self):
+        if self._optimistic_state is not None:
+            self._optimistic_state = None
+        super()._handle_coordinator_update()


### PR DESCRIPTION
**Summary**: Adds two select entities to configure default mode via settings and current mode via /api/device/command.

**Why**: Expose key operating modes via HA UI; aligns with aggregated coordinator data.


**Compatibility**: Fallback device_info; transforms settings fields for PUT; tolerates missing endpoints.

**Risk**: Low; additive.